### PR TITLE
use TLSv1 by default and fallback to SSLv3 when needed

### DIFF
--- a/libsonic/connection.py
+++ b/libsonic/connection.py
@@ -34,11 +34,17 @@ class HTTPSConnectionV3(httplib.HTTPSConnection):
         if self._tunnel_host:
             self.sock = sock
             self._tunnel()
+        # TODO: switch this to Python >= 2.7.9 SSLContext when available
         try:
-            self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file, ssl_version=ssl.PROTOCOL_SSLv3)
-        except ssl.SSLError, e:
-            print("Trying SSLv3.")
-            self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file, ssl_version=ssl.PROTOCOL_SSLv23)           
+            print("[warn] SSL certificates might not be validated!")
+            self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
+                                        ssl_version=ssl.PROTOCOL_TLSv1)
+        except ssl.SSLError:
+            print("[error] fallback to SSLv3. Please consider using HTTP or a "
+                  "sane TLS config")
+            self.sock = ssl.wrap_socket(sock, self.key_file, self.cert_file,
+                                        ssl_version=ssl.PROTOCOL_SSLv23)           
+
 
 class HTTPSHandlerV3(urllib2.HTTPSHandler):
     def https_open(self, req):


### PR DESCRIPTION
The library used to fail to connect to a server which does not
permit SSLv3. I re-enabled SSLv3 in order to use this library.

With the disclosure of CVE-2014-3566 this is unwanted behaviour.

With this patch, by default, TLSv1 is tried. If it's not available
the library downgrades to SSLv3.

Even though this is unwanted behaviour, this patch should allows
the client to be used with a server that does not allow SSLv3
while not breaking backwards compatibility.

(Since it's hard to make the client make arbitrary requests, I think
this is reasonable behaviour).
