### PR TITLE
Album ids are allowed to be strings, so don't cast.

### DIFF
--- a/libsonic/connection.py
+++ b/libsonic/connection.py
@@ -2560,7 +2560,7 @@ class Connection(object):
         methodName = 'getAlbumInfo'
         viewName = '%s.view' % methodName
 
-        q = {'id': int(aid)}
+        q = {'id': aid}
         req = self._getRequest(viewName, q)
         res = self._doInfoReq(req)
         self._checkStatus(res)
@@ -2577,7 +2577,7 @@ class Connection(object):
         methodName = 'getAlbumInfo2'
         viewName = '%s.view' % methodName
 
-        q = {'id': int(aid)}
+        q = {'id': aid}
         req = self._getRequest(viewName, q)
         res = self._doInfoReq(req)
         self._checkStatus(res)


### PR DESCRIPTION
As it says on the tin -- don't force album ids to be ints, strings are allowed.