### PR TITLE
Add salt token support

### DIFF
--- a/libsonic/connection.py
+++ b/libsonic/connection.py
@@ -115,15 +115,12 @@ class Connection(object):
         self._legacyAuth = legacyAuth
         self._useGET = useGET
 
-        if password is None and (salt is None or token is None):
-            raise CredentialError('You must specify either a password or both salt and token arguments.')
-
         self._netrc = None
         if useNetrc is not None:
             self._process_netrc(useNetrc)
-        elif username is None or password is None:
+        elif username is None or (password is None and (salt is None or token is None)):
             raise CredentialError('You must specify either a username/password '
-                'combination or "useNetrc" must be either True or a string '
+                'combination or salt/token combination or "useNetrc" must be either True or a string '
                 'representing a path to a netrc file')
 
         self._port = int(port)


### PR DESCRIPTION
This PR allows the caller to pass in salt/token arguments in order to make the pain of having plaintext auth a little bit less severe. 